### PR TITLE
fix: sorting authors is wrong

### DIFF
--- a/create-tag
+++ b/create-tag
@@ -211,7 +211,7 @@ def main():
     output = {
         "tag_name": new_name,
         "release_body_path": release_body_path,
-        "commit_authors": ",".join(sorted(commit_authors)),
+        "commit_authors": ",".join(commit_authors),
     }
     output = "\n".join(f"{k}={v}".format(k, v) for k, v in output.items())
     if output_path := os.environ.get("GITHUB_OUTPUT"):


### PR DESCRIPTION
the list of authors is the same as the changes found in the release.
The list of commits is totally wrong and needs to be fixed.
We just need to stop ordering the commit_authors by alphabetical order for now!