### PR TITLE
fix: include deploying actor in commit_authors

### DIFF
--- a/create-tag
+++ b/create-tag
@@ -156,6 +156,7 @@ def main():
         )
     ]
     commit_authors = set()
+    commit_authors.add(actor)
 
     if last_tag:
         by_type = collections.defaultdict(list)
@@ -190,16 +191,17 @@ def main():
                 message_lines.append(f" - {change}")
             message_lines.append("")
 
-        if github_client is not None and author_to_sha:
-            # Map commit authors to GitHub usernames via commit SHA lookup
-            gh_repo = github_client.get_repo(args.repository)
-            for email, sha in author_to_sha.items():
-                try:
-                    gh_commit = gh_repo.get_commit(sha)
-                    if gh_commit.author:
-                        commit_authors.add(gh_commit.author.login)
-                except Exception:
-                    logging.debug(f"could not look up GitHub user for {email}")
+        # FIXME we don't want to add the commit_authors until the list is fixed
+        # if github_client is not None and author_to_sha:
+        #     # Map commit authors to GitHub usernames via commit SHA lookup
+        #     gh_repo = github_client.get_repo(args.repository)
+        #     for email, sha in author_to_sha.items():
+        #         try:
+        #             gh_commit = gh_repo.get_commit(sha)
+        #             if gh_commit.author:
+        #                 commit_authors.add(gh_commit.author.login)
+        #         except Exception:
+        #             logging.debug(f"could not look up GitHub user for {email}")
 
     release_body_path = f"release_notes-{new_name}.txt"
     with open(os.path.join(args.checkout_dir, release_body_path), "w") as tf:

--- a/create-tag
+++ b/create-tag
@@ -47,6 +47,7 @@ class CommitMessage(object):
     scope: Optional[str]
     description: str
     author: str
+    sha: str
     breaking_changes: List[str]
 
     @classmethod
@@ -62,6 +63,7 @@ class CommitMessage(object):
                 scope=md.group("scope"),
                 description=md.group("description"),
                 author=commit.author.email,
+                sha=commit.hexsha,
                 breaking_changes=cls.BREAKING_CHANGE_RE.findall(body),
             )
         else:
@@ -160,9 +162,14 @@ def main():
         by_type["feat"] = []
         by_type["fix"] = []
         change_authors = set()
+
+        # email of author -> SHA of the first commit found in changes
+        author_to_sha = {}
         for change in enumerate_changes(repo, last_tag, commit):
             by_type[change.type].append(f"{change.description} ({change.author})")
             change_authors.add(change.author)
+            if change.author not in author_to_sha:
+                author_to_sha[change.author] = change.sha
             for breaker in change.breaking_changes:
                 by_type["BREAKING CHANGES"].append(f"{breaker} ({change.author})")
         delta = timestamp - last_tag_date
@@ -183,14 +190,14 @@ def main():
                 message_lines.append(f" - {change}")
             message_lines.append("")
 
-        if github_client is not None and change_authors:
-            # Map commit emails to GitHub usernames
-            for email in change_authors:
+        if github_client is not None and author_to_sha:
+            # Map commit authors to GitHub usernames via commit SHA lookup
+            gh_repo = github_client.get_repo(args.repository)
+            for email, sha in author_to_sha.items():
                 try:
-                    users = github_client.search_users(f"{email} in:email")
-                    for user in users:
-                        commit_authors.add(user.login)
-                        break
+                    gh_commit = gh_repo.get_commit(sha)
+                    if gh_commit.author:
+                        commit_authors.add(gh_commit.author.login)
                 except Exception:
                     logging.debug(f"could not look up GitHub user for {email}")
 


### PR DESCRIPTION
## Summary
- Add the deploying actor (`GITHUB_ACTOR`) to `commit_authors` so the deployer is always included
- Temporarily disable the commit SHA-based author lookup until the author list logic is finalized

## Test plan
- [ ] Verify `commit_authors` output includes the deploying actor
- [ ] Verify tag creation still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)