### PR TITLE
fix: no sorting of authors names 

### DIFF
--- a/create-tag
+++ b/create-tag
@@ -155,8 +155,8 @@ def main():
             who=actor,
         )
     ]
-    commit_authors = set()
 
+    commit_authors = set()
     if last_tag:
         by_type = collections.defaultdict(list)
         by_type["feat"] = []
@@ -212,8 +212,9 @@ def main():
     output = {
         "tag_name": new_name,
         "release_body_path": release_body_path,
-        "commit_authors": ",".join(sorted(commit_authors))
+        "commit_authors": ",".join(commit_authors)
     }
+
     output = "\n".join(f"{k}={v}".format(k, v) for k, v in output.items())
     if output_path := os.environ.get("GITHUB_OUTPUT"):
         with open(output_path, "w") as f:


### PR DESCRIPTION
I don't think we want to sort authors alphabetically because if we mention in cloud deploy notifier. it is better to keep the sorting per commits